### PR TITLE
Gapless chunked recordings with InputStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,18 @@ Available audio devices:
 
 You can customize the recording using various command-line arguments:
 
-- **Chunk Duration (`-d` or `--duration`)**: Duration of each recording chunk in seconds. Default is `60` seconds.
-- **Total Duration (`-t` or `--total-duration`)**: Total duration of recording in seconds. If not specified, the script runs indefinitely.
-- **Sampling Rate (`-r` or `--samplerate`)**: Sampling rate in Hertz. Default is `44100` Hz.
-- **Channels (`-c` or `--channels`)**: Number of audio channels. `1` for mono, `2` for stereo. Default is `2`.
-- **Device (`--device`)**: Device index for recording. Use `--print-devices` to find the index.
-- **Help (`-h` or `--help`)**: Show help message and exit.
+- **Chunk Duration** (`-d` or `--duration`): Duration of each recording chunk in seconds.
+- **Total Duration** (`-t` or `--total-duration`): Total duration of recording in seconds. If not specified, the script runs indefinitely until cancelled.
+- **Sampling Rate** (`-r` or `--samplerate`): Sampling rate in Hertz. Default is the maximum samplerate of the selected device if not provided.
+- **Channels** (`-c` or `--channels`): Number of audio channels. Default is the maximum number of input channels of the selected device if not provided.
+- **Device** (`--device`): Device index for recording. Use `--print-devices` to find the index.
+- **Output Directory** (`--output-dir`): Directory where recordings are saved. Default is the current directory (`.`).
+- **Prefix** (`--prefix`): Custom prefix for the filename. Default is `audio_recording`.
+- **Use UTC Time** (`--use-utc`): Use UTC time for the filename timestamp. By default, local time is used.
+- **Align Chunks** (`--align-chunks`): Align recording chunks to specific time boundaries.
+- **File Subtype** (`--subtype`): Specify the sound file subtype (e.g., `PCM_16`, `PCM_24`, `FLOAT`). Default is `PCM_16`.
+- **Print Available Subtypes** (`--print-subtypes`): Print a list of available sound file subtypes and exit.
+- **Help** (`-h` or `--help`): Show help message and exit.
 
 ### Examples
 
@@ -129,24 +135,21 @@ python audio_recorder.py -d 15 -t 120 --device 3 -c 1 -r 48000
 
 This command records mono audio at 48 kHz using device index `3`, in 15-second chunks, for a total of 2 minutes.
 
-## Filename Format
+### Filename Format
 
 Recordings are saved with filenames in the following format:
 
-```
-audio_recording_YYYY-MM-DDTHH_MM_SS.microsecondsZ.wav
-```
+Example: `audio_recording_2023-10-01T14_30_45.123456Z.wav`
 
-- **Example**: `audio_recording_2023-10-01T14_30_45.123456Z.wav`
-- **Components**:
-  - `YYYY-MM-DD`: Year, month, and day.
-  - `T`: Separator indicating the start of the time component.
-  - `HH_MM_SS`: Hour, minute, and second.
-  - `.microseconds`: Microseconds (if not zero).
-  - `Z`: Indicates that the time is in UTC.
+Components:
+- `<prefix>`: Customizable prefix for the filename (default is `audio_recording`).
+- `YYYY-MM-DD`: Year, month, and day.
+- `T`: Separator indicating the start of the time component.
+- `HH_MM_SS`: Hour, minute, and second.
+- `.microseconds`: Microseconds (if not zero).
+- `Z`: Indicates that the time is in UTC if the `--use-utc` option is used.
 
-**Note**: The timestamps are in Coordinated Universal Time (UTC) with microsecond precision.
-
+**Note**: The timestamps can be in either Coordinated Universal Time (UTC) or local time, depending on the `--use-utc` parameter.
 
 
 ## License
@@ -156,3 +159,5 @@ This project is licensed under the [MIT License](LICENSE). You are free to use, 
 ---
 
 **Disclaimer**: Use this software responsibly and ensure compliance with local laws and regulations regarding audio recording and privacy.
+
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A Python script for continuous audio recording in timestamped chunks. This tool 
 
 
    ```bash
-   pip install sounddevice scipy numpy
+   pip install sounddevice soundfile
    ```
 
 **Note:** in case you get issues with PortAudio when trying the audio_recorder, try installing sounddevice via conda-forge instread

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ A Python script for continuous audio recording in timestamped chunks. This tool 
    pip install sounddevice scipy numpy
    ```
 
+**Note:** in case you get issues with PortAudio when trying the audio_recorder, try installing sounddevice via conda-forge instread
+
+```bash
+conda install -c conda-forge python-sounddevice
+```
+
 ## Usage
 
 ### Basic Usage

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -37,7 +37,7 @@ def audio_callback(indata, frames, time, status):
 # Main function
 def main():
     parser = argparse.ArgumentParser(description="Continuous Audio Recording Script")
-    parser.add_argument('-d', '--duration', type=float, default=60, help='Duration of each recording chunk in seconds')
+    parser.add_argument('-d', '--duration', type=float, help='Duration of each recording chunk in seconds')
     parser.add_argument('-t', '--total-duration', type=float, help='Total duration of recording in seconds (default: runs indefinitely until cancelled)')
     parser.add_argument('-r', '--samplerate', type=int, default=44100, help='Sampling rate in Hz')
     parser.add_argument('-c', '--channels', type=int, default=2, help='Number of audio channels')
@@ -53,6 +53,12 @@ def main():
         print("Available audio devices:")
         print(sd.query_devices())
         sys.exit(0)
+
+    # Determine chunk duration and total duration based on input
+    if args.total_duration and not args.duration:
+        args.duration = args.total_duration
+    elif args.duration and not args.total_duration:
+        args.total_duration = args.duration
 
     # Create output directory if it doesn't exist
     output_dir = Path(args.output_dir)

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -39,8 +39,8 @@ def main():
     parser = argparse.ArgumentParser(description="Continuous Audio Recording Script")
     parser.add_argument('-d', '--duration', type=float, help='Duration of each recording chunk in seconds')
     parser.add_argument('-t', '--total-duration', type=float, help='Total duration of recording in seconds (default: runs indefinitely until cancelled)')
-    parser.add_argument('-r', '--samplerate', type=int, default=44100, help='Sampling rate in Hz')
-    parser.add_argument('-c', '--channels', type=int, default=2, help='Number of audio channels')
+    parser.add_argument('-r', '--samplerate', type=int, help='Sampling rate in Hz (default: maximum samplerate of the selected device if not provided)')
+    parser.add_argument('-c', '--channels', type=int, help='Number of audio channels (default: maximum number of input channels of the selected device if not provided)')
     parser.add_argument('--device', type=int, help='Device index for recording')
     parser.add_argument('--print-devices', action='store_true', help='Print list of audio devices and exit')
     parser.add_argument('--print-subtypes', action='store_true', help='Print list of available sound file subtypes and exit')
@@ -60,6 +60,15 @@ def main():
         print("Available sound file subtypes:")
         print(sf.available_subtypes())
         sys.exit(0)
+
+    # Set default samplerate and channels if not provided
+    if args.samplerate is None or args.channels is None:
+        device_info = sd.query_devices(args.device, 'input')
+        if args.samplerate is None:
+            # soundfile expects an int, sounddevice provides a float:
+            args.samplerate = int(device_info['default_samplerate'])
+        if args.channels is None:
+            args.channels = device_info['max_input_channels']
 
     # Determine chunk duration and total duration based on input
     if args.total_duration and not args.duration:

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import numpy as np
 import argparse
 import sys
+from pathlib import Path
 
 # Function to convert datetime to formatted string
 def dt_to_str(dt):
@@ -19,14 +20,14 @@ def dt_to_str(dt):
         return dt_str
 
 # Function to generate timestamped filename
-def get_timestamped_filename(prefix, use_utc=False):
+def get_timestamped_filename(prefix, output_dir, use_utc=False):
     if use_utc:
         now = datetime.now(timezone.utc)
     else:
         now = datetime.now()
     timestamp_str = dt_to_str(now)
     filename = f"{prefix}_{timestamp_str}.wav"
-    return filename
+    return output_dir / filename
 
 # Function to record audio chunk
 def record_audio_chunk(duration, fs, channels, device=None):
@@ -59,12 +60,18 @@ def main():
     parser.add_argument('--print-devices', action='store_true', help='Print list of audio devices and exit')
     parser.add_argument('--prefix', type=str, default='audio_recording', help='Custom prefix for the filename')
     parser.add_argument('--use-utc', action='store_true', help='Use UTC time for the filename timestamp (default is local time)')
+    parser.add_argument('--output-dir', type=str, default='.', help='Output directory for the recording files')
     args = parser.parse_args()
 
     if args.print_devices:
         print("Available audio devices:")
         print(sd.query_devices())
         sys.exit(0)
+
+    # Create output directory if it doesn't exist
+    output_dir = Path(args.output_dir)
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
 
     start_time = datetime.now()
     elapsed_time = 0
@@ -76,7 +83,7 @@ def main():
                 print("Total recording duration reached. Exiting.")
                 break
 
-            filename = get_timestamped_filename(args.prefix, use_utc=args.use_utc)
+            filename = get_timestamped_filename(args.prefix, output_dir, use_utc=args.use_utc)
             audio_data = record_audio_chunk(args.duration, args.samplerate, args.channels, device=args.device)
             save_audio(filename, args.samplerate, audio_data)
 

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -19,10 +19,10 @@ def dt_to_str(dt):
         raise Exception("Got a datetime object not in UTC. Always use UTC.")
 
 # Function to generate timestamped filename
-def get_timestamped_filename():
+def get_timestamped_filename(prefix):
     now = datetime.now(timezone.utc)
     timestamp_str = dt_to_str(now)
-    filename = f"audio_recording_{timestamp_str}.wav"
+    filename = f"{prefix}_{timestamp_str}.wav"
     return filename
 
 # Function to record audio chunk
@@ -54,6 +54,7 @@ def main():
     parser.add_argument('-c', '--channels', type=int, default=2, help='Number of audio channels')
     parser.add_argument('--device', type=int, help='Device index for recording')
     parser.add_argument('--print-devices', action='store_true', help='Print list of audio devices and exit')
+    parser.add_argument('--prefix', type=str, default='audio_recording', help='Custom prefix for the filename')
     args = parser.parse_args()
 
     if args.print_devices:
@@ -71,7 +72,7 @@ def main():
                 print("Total recording duration reached. Exiting.")
                 break
 
-            filename = get_timestamped_filename()
+            filename = get_timestamped_filename(args.prefix)
             audio_data = record_audio_chunk(args.duration, args.samplerate, args.channels, device=args.device)
             save_audio(filename, args.samplerate, audio_data)
 

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -51,6 +51,11 @@ def main():
     parser.add_argument('--subtype', type=str, default='PCM_16', help='Sound file subtype (e.g., PCM_16, PCM_24, FLOAT)')
     args = parser.parse_args()
 
+    if args.device is None:
+        print("No recording device specified. Please choose a device from the available list below:")
+        print(sd.query_devices())
+        sys.exit(1)
+    
     if args.print_devices:
         print("Available audio devices:")
         print(sd.query_devices())

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -43,15 +43,22 @@ def main():
     parser.add_argument('-c', '--channels', type=int, default=2, help='Number of audio channels')
     parser.add_argument('--device', type=int, help='Device index for recording')
     parser.add_argument('--print-devices', action='store_true', help='Print list of audio devices and exit')
+    parser.add_argument('--print-subtypes', action='store_true', help='Print list of available sound file subtypes and exit')
     parser.add_argument('--prefix', type=str, default='audio_recording', help='Custom prefix for the filename')
     parser.add_argument('--use-utc', action='store_true', help='Use UTC time for the filename timestamp (default is local time)')
     parser.add_argument('--output-dir', type=str, default='.', help='Output directory for the recording files')
     parser.add_argument('--align-chunks', action='store_true', help='Align recording chunks to specific time boundaries')
+    parser.add_argument('--subtype', type=str, default='PCM_16', help='Sound file subtype (e.g., PCM_16, PCM_24, FLOAT)')
     args = parser.parse_args()
 
     if args.print_devices:
         print("Available audio devices:")
         print(sd.query_devices())
+        sys.exit(0)
+
+    if args.print_subtypes:
+        print("Available sound file subtypes:")
+        print(sf.available_subtypes())
         sys.exit(0)
 
     # Determine chunk duration and total duration based on input
@@ -101,7 +108,7 @@ def main():
 
                 # Write chunks for the specified duration
                 with sf.SoundFile(filename, mode='x', samplerate=args.samplerate,
-                                  channels=args.channels, subtype='PCM_16') as file:
+                                  channels=args.channels, subtype=args.subtype) as file:
                     chunk_start_time = time.time()
                     while time.time() - chunk_start_time < chunk_duration:
                         file.write(q.get())

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -16,11 +16,14 @@ def dt_to_str(dt):
         dt_str += "Z"
         return dt_str
     else:
-        raise Exception("Got a datetime object not in UTC. Always use UTC.")
+        return dt_str
 
 # Function to generate timestamped filename
-def get_timestamped_filename(prefix):
-    now = datetime.now(timezone.utc)
+def get_timestamped_filename(prefix, use_utc=False):
+    if use_utc:
+        now = datetime.now(timezone.utc)
+    else:
+        now = datetime.now()
     timestamp_str = dt_to_str(now)
     filename = f"{prefix}_{timestamp_str}.wav"
     return filename
@@ -55,6 +58,7 @@ def main():
     parser.add_argument('--device', type=int, help='Device index for recording')
     parser.add_argument('--print-devices', action='store_true', help='Print list of audio devices and exit')
     parser.add_argument('--prefix', type=str, default='audio_recording', help='Custom prefix for the filename')
+    parser.add_argument('--use-utc', action='store_true', help='Use UTC time for the filename timestamp (default is local time)')
     args = parser.parse_args()
 
     if args.print_devices:
@@ -72,7 +76,7 @@ def main():
                 print("Total recording duration reached. Exiting.")
                 break
 
-            filename = get_timestamped_filename(args.prefix)
+            filename = get_timestamped_filename(args.prefix, use_utc=args.use_utc)
             audio_data = record_audio_chunk(args.duration, args.samplerate, args.channels, device=args.device)
             save_audio(filename, args.samplerate, audio_data)
 


### PR DESCRIPTION
This pull request does the following:
- replaces .rec with InputStream to ensure gapless recordings
- replaces `scipy.io.wavfile.write` with soundfile (updated readme). This allows for more output subtypes (depending on the microphone used). 
- Added option to choose subtype and option to print avaulable subtypes
- time-aligned chunks of recordings (answers this: https://github.com/jacobdavidson/timestamped_audio_recorder/issues/4)
- fixes total duration and duration issue by removing default duration (fixed this: https://github.com/jacobdavidson/timestamped_audio_recorder/issues/5)
- If samplerate and channel number are not provided, uses the maximum which is possible for the given device
- If device is not provided, print notice and prints device list
- Updated the readme to reflect all added changes